### PR TITLE
App responsive except DeleteModal

### DIFF
--- a/src/Pages/DisplayProducts/Components/AddProduct/AddProductStyles.js
+++ b/src/Pages/DisplayProducts/Components/AddProduct/AddProductStyles.js
@@ -4,19 +4,36 @@ import { AiOutlineClose } from "react-icons/ai";
 export const StyledAddProductWrapper = styled.div`
   display: flex;
   justify-content: right;
-  width: 80rem;
+  width: 18rem;
+  @media screen and (min-width: 600px) {
+    width: 33rem;
+  }
+  @media screen and (min-width: 800px) {
+    width: 47rem;
+  }
+  @media screen and (min-width: 1100px) {
+    width: 65rem;
+  }
+  @media screen and (min-width: 1250px) {
+    width: 75rem;
+  }
 `;
 
 export const StyledAddNewProductButton = styled.button`
+  padding: 0.6rem 0.8rem;
+  font-size: 1rem;
   margin: 3rem 0 0 0;
   border-radius: 0.2rem;
   border: 0;
-  padding: 0.7rem 1rem;
-  font-size: 1.05rem;
   background-color: rgb(96, 96, 97);
   color: white;
   border: 0;
   cursor: pointer;
+
+  @media screen and (min-width: 600px) {
+    padding: 0.7rem 1rem;
+    font-size: 1.05rem;
+  }
 `;
 
 export const StyledFormModalOverlay = styled.div`
@@ -34,6 +51,7 @@ export const StyledFormModalOverlay = styled.div`
 export const StyledFormModal = styled.div`
   background-color: white;
   max-height: 40rem;
+  height: fit-content;
   margin-top: 3rem;
   border-radius: 0.3rem;
   box-shadow: 0 0 0.625rem rgba(0, 0, 0, 0.3);
@@ -59,50 +77,90 @@ export const StyledForm = styled.form`
   display: grid;
   grid-template-rows: auto;
   row-gap: 0.2rem;
-  padding: 0rem 6rem;
+  padding: 0 2.5rem;
   font-family: inherit;
+
+  @media screen and (min-width: 600px) {
+    padding: 0rem 4rem;
+  }
+  @media screen and (min-width: 800px) {
+    padding: 0rem 6rem;
+  }
 `;
 
 export const StyledTitle = styled.h1`
-  font-size: 2rem;
+  font-size: 1.6rem;
   margin: 0;
-  padding-top: 1.4rem;
+  padding: 3rem 0 1rem 0;
+
+  @media screen and (min-width: 600px) {
+    font-size: 2rem;
+  }
 `;
 
 export const StyledLabel = styled.label`
-  padding-top: 0.6rem;
+  padding-top: 0.35rem;
+  font-weight: 500;
+  font-size: 0.8rem;
+
+  @media screen and (min-width: 510px) {
+    font-size: 1rem;
+    padding-top: 0.6rem;
+  }
 `;
 
 export const StyledInput = styled.input`
-  width: 25rem;
+  width: 12rem;
   height: 1.5rem;
+
+  @media screen and (min-width: 510px) {
+    width: 25rem;
+  }
 `;
 
 export const StyledSelect = styled.select`
-  width: 25rem;
+  width: 12rem;
   height: 1.5rem;
+
+  @media screen and (min-width: 510px) {
+    width: 25rem;
+  }
 `;
 
 export const StyledTextArea = styled.textarea`
-  width: 25rem;
+  width: 12rem;
   font-family: inherit;
+
+  @media screen and (min-width: 510px) {
+    width: 25rem;
+  }
 `;
 
 export const StyledButtonsSection = styled.section`
   display: flex;
   justify-content: right;
-  gap: 1rem;
-  padding: 1.4rem 0;
+  gap: 0.7rem;
+  padding: 1.4rem 0 0.5rem 0;
+  margin: 0.5rem 0;
+
+  @media screen and (min-width: 600px) {
+    gap: 1rem;
+    padding: 1.4rem 0;
+  }
 `;
 
 export const StyledFormButton = styled.button`
-  padding: 0.7rem;
-  font-size: 1rem;
+  padding: 0.5rem;
   border: 0;
+  font-size: 0.7rem;
   border-radius: 0.2rem;
 
   &:hover {
     cursor: pointer;
+  }
+  @media screen and (min-width: 600px) {
+    font-size: 1rem;
+    padding: 0.8rem;
   }
 `;
 

--- a/src/Pages/DisplayProducts/Components/EditProduct/EditProduct.jsx
+++ b/src/Pages/DisplayProducts/Components/EditProduct/EditProduct.jsx
@@ -17,6 +17,7 @@ import {
   StyledTitle,
   StyledFormValidationError,
 } from "../AddProduct/AddProductStyles";
+
 import { editProduct } from "../../Api/Methods";
 
 const EditProduct = ({

--- a/src/Pages/DisplayProducts/Components/ProductPage/ProductPageStyles.js
+++ b/src/Pages/DisplayProducts/Components/ProductPage/ProductPageStyles.js
@@ -3,21 +3,39 @@ import styled from "styled-components";
 export const StyledProductPageSection = styled.section`
   display: flex;
   flex-direction: column;
+  padding-bottom: 15rem;
 `;
 
 export const StyledProductSection = styled.section`
-  margin: 6rem 0 2rem 0;
-  gap: 5rem;
+  margin: 4rem 1rem 2rem 1rem;
+  gap: 2rem;
   display: flex;
+  flex-direction: column;
+  align-items: left;
+
+  @media screen and (min-width: 800px) {
+    gap: 5rem;
+    flex-direction: row;
+  }
 `;
 
 export const StyledProductPageImage = styled.img`
-  min-height: 20rem;
-  max-height: 30rem;
-  max-width: 30rem;
+  max-height: 22rem;
+  max-width: 18rem;
   box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px,
     rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
   box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 3px, rgba(0, 0, 0, 0.24) 0px 1px 2px;
+
+  @media screen and (min-width: 600px) {
+    max-height: 22rem;
+    max-width: 25rem;
+  }
+
+  @media screen and (min-width: 800px) {
+    min-height: 22rem;
+    max-height: 30rem;
+    max-width: 30rem;
+  }
 `;
 
 export const StyledProductPageProductDetails = styled.div`
@@ -26,22 +44,41 @@ export const StyledProductPageProductDetails = styled.div`
 `;
 
 export const StyledProductPageTitle = styled.h1`
+  font-size: 1.8rem;
   font-weight: 600;
-  font-size: 2rem;
+
+  @media screen and (min-width: 800px) {
+    font-size: 1.8rem;
+  }
 `;
 
 export const StyledProductCategory = styled.p`
-  font-size: 1rem;
-  padding-bottom: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding-bottom: 0.3rem;
+
+  @media screen and (min-width: 800px) {
+    padding-bottom: 0.5rem;
+    font-size: 1rem;
+  }
 `;
 
 export const StyledProductDescription = styled.p`
-  font-size: 1rem;
+  font-size: 0.8rem;
+
+  @media screen and (min-width: 800px) {
+    font-size: 1rem;
+  }
 `;
 
 export const StyledProductStats = styled.div`
-  font-size: 1.2rem;
-  padding-top: 5rem;
+  font-size: 0.9rem;
+  padding-top: 0.5rem;
+
+  @media screen and (min-width: 800px) {
+    font-size: 1.2rem;
+    padding-top: 5rem;
+  }
 `;
 
 export const StyledProductRating = styled.p`

--- a/src/Pages/DisplayProducts/Components/ProductsGrid/ProductsGridStyles.js
+++ b/src/Pages/DisplayProducts/Components/ProductsGrid/ProductsGridStyles.js
@@ -4,7 +4,7 @@ export const StyledProductCard = styled.div`
   min-height: 32rem;
   height: fit-content;
   background-color: rgb(255, 255, 255);
-  width: 16rem;
+  width: 15.7rem;
   border-radius: 0.3rem;
   display: flex;
   flex-direction: column;
@@ -16,6 +16,18 @@ export const StyledProductCard = styled.div`
       rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
   }
   position: relative;
+
+  @media screen and (min-width: 800px) {
+    width: 14.5rem;
+  }
+
+  @media screen and (min-width: 1100px) {
+    width: 15rem;
+  }
+
+  @media screen and (min-width: 1250px) {
+    width: 16rem;
+  }
 `;
 
 export const StyledDotsButton = styled.button`

--- a/src/Pages/DisplayProducts/DisplayProductsStyles.js
+++ b/src/Pages/DisplayProducts/DisplayProductsStyles.js
@@ -3,8 +3,28 @@ import styled from "styled-components";
 export const StyledGridWrapper = styled.main`
   display: grid;
   margin: 6rem 7rem;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
-  row-gap: 5rem;
-  column-gap: 4rem;
+  grid-template-columns: 1fr;
+  row-gap: 3rem;
   justify-items: center;
+
+  @media screen and (min-width: 600px) {
+    row-gap: 5rem;
+    grid-template-columns: 1fr 1fr;
+    column-gap: 2.25rem;
+  }
+
+  @media screen and (min-width: 800px) {
+    grid-template-columns: 1fr 1fr 1fr;
+    column-gap: 2rem;
+  }
+
+  @media screen and (min-width: 1100px) {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    column-gap: 2rem;
+  }
+
+  @media screen and (min-width: 1250px) {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    column-gap: 2.5rem;
+  }
 `;

--- a/src/Shared/Components/NavBar/NavBarStyles.js
+++ b/src/Shared/Components/NavBar/NavBarStyles.js
@@ -33,6 +33,7 @@ export const StyledTitle = styled.h1`
   font-weight: 600;
   font-size: 1.5rem;
   padding: 0.3rem;
+  padding-left: 1rem;
   text-decoration: none;
 `;
 


### PR DESCRIPTION
### Purpose
- Make app visually accessible for users across all devices.
- Breakpoints: 510px, 600px, 800px, 1100px, 1250px

### Changes
- Made whole app responsive except delete modal (should be completed after merging)
- Primarily adjusted Styles.js files of components.

### Screenshots:
#### Desktop view:
![Api_commerce_(Desktop)](https://github.com/iIqbalSazim/api-commerce/assets/144238479/86a550ad-0ab6-4a08-8047-e029b85c0934)

#### iPhone 12 view:
![Api commerce_(iPhone 12 Pro)](https://github.com/iIqbalSazim/api-commerce/assets/144238479/5278fcfa-e647-436d-a655-fc0fc0f7a5a0)

#### iPad Air view:
![Api_commerce_(iPad Air)](https://github.com/iIqbalSazim/api-commerce/assets/144238479/f086b233-7abe-49c6-af95-a2fc22e04389)

#### iPad Mini view:
![Api_commerce_(iPad Mini)](https://github.com/iIqbalSazim/api-commerce/assets/144238479/779f4031-b8f1-49c1-a385-fc5cf9d7f1b9)